### PR TITLE
Allow context to be rendered without script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "umami-analytics-next",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "umami-analytics-next",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umami-analytics-next",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple type-safe integration between the Umami Analytics API, loaded using Next's Script component",
   "keywords": [
     "analytics",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,8 +17,8 @@ type UmamiAnalyticsContextType = {
   domains?: string[];
   loaded: boolean;
   processUrl?: (url: string) => string;
-  src: string;
-  websiteId: string;
+  src?: string;
+  websiteId?: string;
 };
 
 type Props = Omit<UmamiAnalyticsContextType, "loaded"> & {
@@ -43,12 +43,6 @@ export const umamiAnalyticsContextFactory = function <
     ...options
   }: Props) {
     const [loaded, setLoaded] = useState(false);
-    if (!src) {
-      throw new Error("Script source is required");
-    }
-    if (!websiteId) {
-      throw new Error("websiteId is required");
-    }
 
     return (
       <>
@@ -57,18 +51,20 @@ export const umamiAnalyticsContextFactory = function <
         >
           {children}
         </UmamiAnalyticsContext.Provider>
-        <Script
-          async
-          data-auto-track={autoTrack.toString()}
-          data-website-id={websiteId}
-          src={src}
-          {...(options.domains !== undefined &&
-            Array.isArray(options.domains) &&
-            options.domains.length > 0 && {
-              "data-domains": options.domains.join(","),
-            })}
-          onLoad={() => setLoaded(true)}
-        />
+        {!!src && !!websiteId && (
+          <Script
+            async
+            data-auto-track={autoTrack.toString()}
+            data-website-id={websiteId}
+            src={src}
+            {...(options.domains !== undefined &&
+              Array.isArray(options.domains) &&
+              options.domains.length > 0 && {
+                "data-domains": options.domains.join(","),
+              })}
+            onLoad={() => setLoaded(true)}
+          />
+        )}
       </>
     );
   };


### PR DESCRIPTION
Consumers of this package will use `useUmami` in this code. However, for that, the ContextProvider must always be rendered, even if we don't want analytics. Before this fix, users would skip rendering the Provider to avoid loading the script, which would then break the `useUmami()` hook.

With this change, now users can render the provider, and the Script will only be needed if both `src` and `websiteId` are provided